### PR TITLE
Fix install with hatchling >= 1.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,9 @@ combine-as-imports = true
 force-sort-within-sections = true
 known-first-party = ["pelican"]
 
+[tool.hatch.build.targets.wheel]
+packages = ["pelican"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["pelican"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,6 @@ known-first-party = ["pelican"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["pelican"]


### PR DESCRIPTION
Explicitly specify the top-level package name in order to fix installing with hatchling >= 1.19.0.  These new versions default to installing packages that match the project name only, and fail if one cannot be found.